### PR TITLE
Add ability to get updates without use of an IMetadataSync

### DIFF
--- a/src/microsoft-update-upstream-package-source/Sources/UpstreamCategoriesSource.cs
+++ b/src/microsoft-update-upstream-package-source/Sources/UpstreamCategoriesSource.cs
@@ -91,46 +91,60 @@ namespace Microsoft.PackageGraph.MicrosoftUpdate.Source
             return batches;
         }
 
-        /// <summary>
-        /// Retrieves categories from the upstream source
-        /// </summary>
-        /// <param name="cancelToken">Cancellation token</param>
-        /// <returns>List of Microsoft Update categories</returns>
-        public List<MicrosoftUpdatePackage> GetCategories(CancellationToken cancelToken)
-        {
-            var categoriesList = new List<MicrosoftUpdatePackage>();
+		/// <summary>
+		/// Retrieves categories from the upstream source
+		/// </summary>
+		/// <param name="cancelToken">Cancellation token</param>
+		/// <param name="excludedPackageIds">A list of GUIDs to exclude from the retrieval</param>
+		/// <returns>List of Microsoft Update categories</returns>
+		public List<MicrosoftUpdatePackage> GetCategories(CancellationToken cancelToken, IEnumerable<Guid> excludedPackageIds = null)
+		{
+			excludedPackageIds ??= Array.Empty<Guid>();
 
-            RetrievePackageIdentities();
+			var categoriesList = new List<MicrosoftUpdatePackage>();
 
-            var batches = CreateBatchedListFromFlatList(_Identities, 50);
+			RetrievePackageIdentities();
 
-            var progressArgs = new PackageStoreEventArgs() { Total = _Identities.Count, Current = 0 };
-            batches.ForEach(batch =>
-            {
-                if (cancelToken.IsCancellationRequested)
-                {
-                    return;
-                }
+			var unavailableUpdates = _Identities
+				.Where(u => !excludedPackageIds.Any(e => u.ID == e))
+				.ToList();
 
-                var retrievedBatch = _Client.GetUpdateDataForIds(batch.ToList());
+			if (unavailableUpdates.Count > 0)
+			{
+				var batches = CreateBatchedListFromFlatList(unavailableUpdates, 50);
 
-                lock (categoriesList)
-                {
-                    categoriesList.AddRange(retrievedBatch);
-                }
+				var progressArgs = new PackageStoreEventArgs() { Total = unavailableUpdates.Count, Current = 0 };
+				batches.ForEach(batch =>
+				{
+					if (cancelToken.IsCancellationRequested)
+					{
+						return;
+					}
 
-                lock (progressArgs)
-                {
-                    progressArgs.Current++;
-                    MetadataCopyProgress?.Invoke(this, progressArgs);
-                }
-            });
+					var retrievedBatch = _Client.GetUpdateDataForIds(batch.ToList());
 
-            return categoriesList;
-        }
+					lock (categoriesList)
+					{
+						categoriesList.AddRange(retrievedBatch);
+					}
 
-        /// <inheritdoc cref="IMetadataSource.CopyTo(IMetadataSink, CancellationToken)"/>
-        public void CopyTo(IMetadataSink destination, CancellationToken cancelToken)
+					lock (progressArgs)
+					{
+						progressArgs.Current += retrievedBatch.Count;
+						MetadataCopyProgress?.Invoke(this, progressArgs);
+					}
+				});
+			}
+			else
+			{
+				MetadataCopyProgress?.Invoke(this, new PackageStoreEventArgs());
+			}
+
+			return categoriesList;
+		}
+
+		/// <inheritdoc cref="IMetadataSource.CopyTo(IMetadataSink, CancellationToken)"/>
+		public void CopyTo(IMetadataSink destination, CancellationToken cancelToken)
         {
             RetrievePackageIdentities();
 

--- a/src/microsoft-update-upstream-package-source/Sources/UpstreamUpdatesSource.cs
+++ b/src/microsoft-update-upstream-package-source/Sources/UpstreamUpdatesSource.cs
@@ -127,7 +127,11 @@ namespace Microsoft.PackageGraph.MicrosoftUpdate.Source
                     }                    
                 });
             }
-        }
+			else
+			{
+				MetadataCopyProgress?.Invoke(this, new PackageStoreEventArgs());
+			}
+		}
 
         /// <inheritdoc cref="IMetadataSource.CopyTo(IMetadataSink, IMetadataFilter, CancellationToken)"/>
         public void CopyTo(IMetadataSink destination, IMetadataFilter filter, CancellationToken cancelToken)

--- a/src/microsoft-update-upstream-package-source/Sources/UpstreamUpdatesSource.cs
+++ b/src/microsoft-update-upstream-package-source/Sources/UpstreamUpdatesSource.cs
@@ -87,8 +87,60 @@ namespace Microsoft.PackageGraph.MicrosoftUpdate.Source
             return batches;
         }
 
-        /// <inheritdoc cref="IMetadataSource.CopyTo(IMetadataSink, CancellationToken)"/>
-        public void CopyTo(IMetadataSink destination, CancellationToken cancelToken)
+		/// <summary>
+		/// Retrieves products from the upstream source
+		/// </summary>
+		/// <param name="cancelToken">Cancellation token</param>
+		/// <param name="excludedPackageIds">A list of GUIDs to exclude from the retrieval</param>
+		/// <returns>List of Microsoft Update updates</returns>
+		public List<MicrosoftUpdatePackage> GetUpdates(CancellationToken cancelToken, IEnumerable<Guid> excludedPackageIds = null)
+		{
+			excludedPackageIds ??= Array.Empty<Guid>();
+
+			var updatesList = new List<MicrosoftUpdatePackage>();
+
+			RetrievePackageIdentities();
+
+			var unavailableUpdates = _Identities
+				.Where(u => !excludedPackageIds.Any(e => u.ID == e))
+				.ToList();
+
+			if (unavailableUpdates.Count > 0)
+			{
+				var batches = CreateBatchedListFromFlatList(unavailableUpdates, 50);
+
+				var progressArgs = new PackageStoreEventArgs() { Total = unavailableUpdates.Count, Current = 0 };
+				batches.ForEach(batch =>
+				{
+					if (cancelToken.IsCancellationRequested)
+					{
+						return;
+					}
+
+					var retrievedBatch = _Client.GetUpdateDataForIds(batch.ToList());
+
+					lock (updatesList)
+					{
+						updatesList.AddRange(retrievedBatch);
+					}
+
+					lock (progressArgs)
+					{
+						progressArgs.Current += retrievedBatch.Count;
+						MetadataCopyProgress?.Invoke(this, progressArgs);
+					}
+				});
+			}
+			else
+			{
+				MetadataCopyProgress?.Invoke(this, new PackageStoreEventArgs());
+			}
+
+			return updatesList;
+		}
+
+		/// <inheritdoc cref="IMetadataSource.CopyTo(IMetadataSink, CancellationToken)"/>
+		public void CopyTo(IMetadataSink destination, CancellationToken cancelToken)
         {
             RetrievePackageIdentities();
 


### PR DESCRIPTION
Implement `GetUpdates` similar to `GetCategories` in `UpstreamCategoriesSource` so that updates can be retrieved without the use of an IMetadataSync.

Additionally, add the ability to filter Updates and Categories by GUID so that they aren't retrieved from the upstream server.