### PR TITLE
don't ask for confirmation when syncing content

### DIFF
--- a/src/tools/upsync/ContentSync.cs
+++ b/src/tools/upsync/ContentSync.cs
@@ -47,11 +47,7 @@ namespace Microsoft.PackageGraph.Utilitites.Upsync
 
             filesToDownload = filesToDownload.Distinct().ToList();
 
-            Console.WriteLine($"Sync {filesToDownload.Count} files, {filesToDownload.Sum(f => (long)f.Size)} bytes. Continue? (y/n)");
-            if (Console.ReadKey().Key != ConsoleKey.Y)
-            {
-                return;
-            }
+            Console.WriteLine($"Sync {filesToDownload.Count} files, {filesToDownload.Sum(f => (long)f.Size)} bytes.");
 
             CancellationTokenSource cancelTokenSource = new();
             contentStore.Progress += ContentStore_Progress;


### PR DESCRIPTION
Kind of useless when running headless. Alternative would be checking if there is a console, but what is the point of running that command if you don't want it?